### PR TITLE
feat: add Linux/macOS printing support via CUPS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ email = "18668070425@163.com"
 
 [dependencies]
 tauri = { version = "2.7.0" }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "2"
 base64 = "0.22"
 tempfile = "3.8"

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -1,56 +1,56 @@
 use serde::de::DeserializeOwned;
 use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
-use crate::models::*;
 use crate::declare::PrintHtmlOptions;
+use crate::models::*;
 
 pub fn init<R: Runtime, C: DeserializeOwned>(
-  app: &AppHandle<R>,
-  _api: PluginApi<R, C>,
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
 ) -> crate::Result<Printer<R>> {
-  Ok(Printer(app.clone()))
+    Ok(Printer(app.clone()))
 }
 
 /// Access to the printer APIs.
 pub struct Printer<R: Runtime>(AppHandle<R>);
 
 impl<R: Runtime> Printer<R> {
-  pub fn ping(&self, payload: PingRequest) -> crate::Result<PingResponse> {
-    Ok(PingResponse {
-      value: payload.value,
-    })
-  }
+    pub fn ping(&self, payload: PingRequest) -> crate::Result<PingResponse> {
+        Ok(PingResponse {
+            value: payload.value,
+        })
+    }
 
-  pub fn get_printers(&self) -> crate::Result<String> {
-    #[cfg(target_os = "windows")]
-    {
-      Ok(crate::windows::get_printers())
+    pub fn get_printers(&self) -> crate::Result<String> {
+        #[cfg(target_os = "windows")]
+        {
+            Ok(crate::windows::get_printers())
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Ok(crate::linux::get_printers())
+        }
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-      Err(crate::Error::UnsupportedPlatform)
-    }
-  }
 
-  pub fn get_printer_by_name(&self, name: String) -> crate::Result<String> {
-    #[cfg(target_os = "windows")]
-    {
-      Ok(crate::windows::get_printers_by_name(name))
+    pub fn get_printer_by_name(&self, name: String) -> crate::Result<String> {
+        #[cfg(target_os = "windows")]
+        {
+            Ok(crate::windows::get_printers_by_name(name))
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Ok(crate::linux::get_printers_by_name(name))
+        }
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-      Err(crate::Error::UnsupportedPlatform)
-    }
-  }
 
-  pub fn print_html(&self, options: PrintHtmlOptions) -> crate::Result<String> {
-    #[cfg(target_os = "windows")]
-    {
-      Ok(crate::windows::print_html(options))
+    pub fn print_html(&self, options: PrintHtmlOptions) -> crate::Result<String> {
+        #[cfg(target_os = "windows")]
+        {
+            Ok(crate::windows::print_html(options))
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Ok(crate::linux::print_html(options))
+        }
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-      Err(crate::Error::UnsupportedPlatform)
-    }
-  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 mod declare;
 mod fsys;
+
+#[cfg(target_os = "windows")]
 mod windows;
+#[cfg(not(target_os = "windows"))]
+mod linux;
 
 use tauri::{
     plugin::{Builder, TauriPlugin},
@@ -27,24 +31,6 @@ use desktop::Printer;
 #[cfg(mobile)]
 use mobile::Printer;
 
-/**
- * 测试打印机连接
- */
-#[tauri::command]
-async fn ping<R: Runtime>(app: tauri::AppHandle<R>, payload: PingRequest) -> Result<PingResponse> {
-    app.printer().ping(payload)
-}
-
-/**
- * 打印 HTML 内容
- */
-#[tauri::command(rename_all = "snake_case")]
-async fn print_html<R: Runtime>(app: tauri::AppHandle<R>, options: PrintHtmlOptions) -> Result<String> {
-    println!("print_html: {:?}", options.print_settings);
-    app.printer().print_html(options)
-}
-
-
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the printer APIs.
 pub trait PrinterExt<R: Runtime> {
     fn printer(&self) -> &Printer<R>;
@@ -56,234 +42,166 @@ impl<R: Runtime, T: Manager<R>> crate::PrinterExt<R> for T {
     }
 }
 
-/**
- * 创建临时文件
- * @param buffer_data base64字符串
- * @param filename 文件名
- * @returns 临时文件路径
- */
+#[tauri::command]
+async fn ping<R: Runtime>(
+    app: tauri::AppHandle<R>,
+    payload: PingRequest,
+) -> Result<PingResponse> {
+    app.printer().ping(payload)
+}
+
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|create_temp_file')`.
+async fn print_html<R: Runtime>(
+    app: tauri::AppHandle<R>,
+    options: PrintHtmlOptions,
+) -> Result<String> {
+    app.printer().print_html(options)
+}
+
+/// Write a base64-encoded buffer to a temp file; returns the file path on success.
+#[tauri::command(rename_all = "snake_case")]
 fn create_temp_file(buffer_data: String, filename: String) -> String {
     let dir = env::temp_dir();
-    let result = fsys::create_file_from_base64(
-        buffer_data.as_str(),
-        format!("{}{}", dir.display(), filename).as_str(),
-    );
-    if result.is_ok() {
-        return format!("{}{}", dir.display(), filename);
+    let path = format!("{}{}", dir.display(), filename);
+    match fsys::create_file_from_base64(buffer_data.as_str(), &path) {
+        Ok(_) => path,
+        Err(_) => String::new(),
     }
-    return "".to_owned();
 }
 
-/**
- * 删除临时文件
- * @param filename 文件名
- * @returns 删除结果
- */
+/// Remove a file from the temp directory.
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|create_temp_file')`.
 fn remove_temp_file(filename: String) -> bool {
     let dir = env::temp_dir();
-    let result = fsys::remove_file(format!("{}{}", dir.display(), filename).as_str());
-    if result.is_ok() {
-        return true;
-    }
-    return false;
+    fsys::remove_file(format!("{}{}", dir.display(), filename).as_str()).is_ok()
 }
 
-/**
- * 获取打印机列表
- */
 #[tauri::command]
-// this will be accessible with `invoke('plugin:printer|get_printers')`.
 fn get_printers() -> String {
-    if cfg!(windows) {
-        return windows::get_printers();
+    #[cfg(target_os = "windows")]
+    {
+        windows::get_printers()
     }
-
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::get_printers()
+    }
 }
 
-/**
- * 获取打印机列表
- * @param printername 打印机名称
- * @returns 打印机列表
- */
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|get_printer_by_name')`.
 fn get_printers_by_name(printername: String) -> String {
-    println!("获取打印机列表: {}", printername);
-    if cfg!(windows) {
-        return windows::get_printers_by_name(printername);
+    #[cfg(target_os = "windows")]
+    {
+        windows::get_printers_by_name(printername)
     }
-
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::get_printers_by_name(printername)
+    }
 }
 
-/**
- * 打印PDF
- * @param id 打印机ID
- * @param path PDF文件路径
- * @param printer_setting 打印机设置
- * @param remove_after_print 打印完成后删除文件
- * @returns 打印结果
- */
-#[tauri::command(rename_all = "snake_case")]    
-// this will be accessible with `invoke('plugin:printer|print_pdf')`.
+/// Print a PDF file.
+/// `print_setting` is the destination printer name; leave empty to use the system default.
+#[tauri::command(rename_all = "snake_case")]
 fn print_pdf(
     id: String,
     path: String,
-    printer_setting: String,
+    print_setting: String,
     remove_after_print: bool,
 ) -> String {
-     
-    if cfg!(windows) {
-        let options = declare::PrintOptions { 
-            id,
-            path,
-            print_setting: printer_setting,
-            remove_after_print: remove_after_print,
-        };
-        return windows::print_pdf(options);
+    let options = declare::PrintOptions {
+        id,
+        path,
+        print_setting,
+        remove_after_print,
+    };
+    #[cfg(target_os = "windows")]
+    {
+        windows::print_pdf(options)
     }
-
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::print_pdf(options)
+    }
 }
 
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|get_jobs')`.
 fn get_jobs(printername: String) -> String {
-    if cfg!(windows) {
-        return windows::get_jobs(printername);
+    #[cfg(target_os = "windows")]
+    {
+        windows::get_jobs(printername)
     }
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::get_jobs(printername)
+    }
 }
 
-/**
- * 获取打印任务列表
- * @param printername 打印机名称
- * @param jobid 打印任务ID
- * @returns 打印任务列表
- */
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|get_jobs_by_id')`.
 fn get_jobs_by_id(printername: String, jobid: String) -> String {
-    if cfg!(windows) {
-        return windows::get_jobs_by_id(printername, jobid);
+    #[cfg(target_os = "windows")]
+    {
+        windows::get_jobs_by_id(printername, jobid)
     }
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::get_jobs_by_id(printername, jobid)
+    }
 }
 
-/**
- * 恢复打印任务
- * @param printername 打印机名称
- * @param jobid 打印任务ID
- * @returns 恢复结果
- */
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|restart_job')`.
 fn resume_job(printername: String, jobid: String) -> String {
-    if cfg!(windows) {
-        return windows::resume_job(printername, jobid);
+    #[cfg(target_os = "windows")]
+    {
+        windows::resume_job(printername, jobid)
     }
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::resume_job(printername, jobid)
+    }
 }
 
-/**
- * 重启打印任务
- * @param printername 打印机名称
- * @param jobid 打印任务ID
- * @returns 重启结果
- */
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|restart_job')`.
 fn restart_job(printername: String, jobid: String) -> String {
-    if cfg!(windows) {
-        return windows::restart_job(printername, jobid);
+    #[cfg(target_os = "windows")]
+    {
+        windows::restart_job(printername, jobid)
     }
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::restart_job(printername, jobid)
+    }
 }
 
-/**
- * 暂停打印任务
- * @param printername 打印机名称
- * @param jobid 打印任务ID
- * @returns 暂停结果
- */
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|pause_job')`.
 fn pause_job(printername: String, jobid: String) -> String {
-    if cfg!(windows) {
-        return windows::pause_job(printername, jobid);
+    #[cfg(target_os = "windows")]
+    {
+        windows::pause_job(printername, jobid)
     }
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::pause_job(printername, jobid)
+    }
 }
 
-/**
- * 删除打印任务
- * @param printername 打印机名称
- * @param jobid 打印任务ID
- * @returns 删除结果
- */
 #[tauri::command(rename_all = "snake_case")]
-// this will be accessible with `invoke('plugin:printer|remove_job')`.
 fn remove_job(printername: String, jobid: String) -> String {
-    if cfg!(windows) {
-        return windows::remove_job(printername, jobid);
+    #[cfg(target_os = "windows")]
+    {
+        windows::remove_job(printername, jobid)
     }
-    return "Unsupported OS".to_string();
+    #[cfg(not(target_os = "windows"))]
+    {
+        linux::remove_job(printername, jobid)
+    }
 }
 
-/**
- * 获取打印机列表
- * @param printername 打印机名称
- * @returns 打印机列表
- */
-pub fn custom_get_printers_by_name(printername: String) -> String {
-    if cfg!(windows) {
-        return windows::get_printers_by_name(printername);
-    }
-
-    return "Unsupported OS".to_string();
-}
-
-/**
- * 打印PDF
- * @param id 打印机ID
- * @param path PDF文件路径
- * @param printer_setting 打印机设置
- * @param remove_after_print 打印完成后删除文件
- * @returns 打印结果
- */
-pub fn custom_print_pdf(
-    id: String,
-    path: String,
-    printer_setting: String,
-    remove_after_print: bool,
-) -> String {
-    if cfg!(windows) {
-        let options = declare::PrintOptions {
-            id,
-            path,
-            print_setting: printer_setting,
-            remove_after_print: remove_after_print,
-        };
-        return windows::print_pdf(options);
-    }
-
-    return "Unsupported OS".to_string();
-}
-
-/**
- * 初始化插件
- * @returns 初始化结果
- */
 /// Initializes the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-  if cfg!(windows) {
+    #[cfg(target_os = "windows")]
     windows::init_windows();
-  }
+
     Builder::new("printer")
         .invoke_handler(tauri::generate_handler![
             ping,
@@ -298,7 +216,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             resume_job,
             restart_job,
             pause_job,
-            remove_job
+            remove_job,
         ])
         .setup(|app, api| {
             #[cfg(mobile)]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,314 @@
+use std::collections::HashMap;
+use std::env;
+use std::process::Command;
+
+use serde_json::{json, Value};
+
+use crate::declare::{PrintHtmlOptions, PrintOptions};
+use crate::fsys::remove_file;
+
+/// List all printers using CUPS `lpstat`.
+/// Returns a JSON array compatible with the Windows Get-Printer format.
+pub fn get_printers() -> String {
+    let printers_out = Command::new("lpstat").args(["-p"]).output().ok();
+    let default_out = Command::new("lpstat").args(["-d"]).output().ok();
+    let devices_out = Command::new("lpstat").args(["-v"]).output().ok();
+
+    let printers_bytes = printers_out.map(|o| o.stdout).unwrap_or_default();
+    let default_bytes = default_out.map(|o| o.stdout).unwrap_or_default();
+    let devices_bytes = devices_out.map(|o| o.stdout).unwrap_or_default();
+
+    let printers_str = String::from_utf8_lossy(&printers_bytes);
+    let default_str = String::from_utf8_lossy(&default_bytes);
+    let devices_str = String::from_utf8_lossy(&devices_bytes);
+
+    // "system default destination: <name>"
+    let default_printer = default_str
+        .trim()
+        .strip_prefix("system default destination: ")
+        .unwrap_or("")
+        .to_string();
+
+    // Build name → device-URI map from "device for <name>: <uri>"
+    let device_map: HashMap<String, String> = devices_str
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("device for ")?;
+            let colon = rest.find(": ")?;
+            Some((rest[..colon].to_string(), rest[colon + 2..].to_string()))
+        })
+        .collect();
+
+    // Parse "printer <NAME> is <STATUS>..." lines
+    let printers: Vec<Value> = printers_str
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("printer ")?;
+            let sep = rest.find(" is ")?;
+            let name = &rest[..sep];
+            let status_str = &rest[sep + 4..];
+            let status = if status_str.starts_with("idle") {
+                "Idle"
+            } else if status_str.starts_with("processing") {
+                "Printing"
+            } else if status_str.starts_with("disabled") || status_str.starts_with("stopped") {
+                "Paused"
+            } else {
+                "Unknown"
+            };
+
+            Some(json!({
+                "Name": name,
+                "DriverName": null,
+                "JobCount": 0,
+                "PrintProcessor": null,
+                "PortName": device_map.get(name).cloned().unwrap_or_default(),
+                "ShareName": null,
+                "ComputerName": null,
+                "PrinterStatus": status,
+                "Shared": false,
+                "Type": 0,
+                "Priority": 1,
+                "IsDefault": name == default_printer,
+            }))
+        })
+        .collect();
+
+    serde_json::to_string(&printers).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Return info for a single printer by name.
+pub fn get_printers_by_name(name: String) -> String {
+    let all: Vec<Value> = serde_json::from_str(&get_printers()).unwrap_or_default();
+    let matched: Vec<&Value> = all
+        .iter()
+        .filter(|p| p["Name"].as_str().unwrap_or("") == name)
+        .collect();
+    serde_json::to_string(&matched).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Print a PDF file using CUPS `lp`.
+/// `options.print_setting` holds the destination printer name (empty = default).
+pub fn print_pdf(options: PrintOptions) -> String {
+    let mut args: Vec<String> = Vec::new();
+
+    if !options.print_setting.is_empty() {
+        args.push("-d".to_string());
+        args.push(options.print_setting.clone());
+    }
+
+    args.push(options.path.clone());
+
+    let result = match Command::new("lp").args(&args).output() {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        Ok(out) => format!("lp error: {}", String::from_utf8_lossy(&out.stderr).trim()),
+        Err(e) => format!("Failed to run lp: {}", e),
+    };
+
+    if options.remove_after_print {
+        let _ = remove_file(&options.path);
+    }
+
+    result
+}
+
+/// Print HTML by converting to PDF with `wkhtmltopdf`, then sending to `lp`.
+pub fn print_html(options: PrintHtmlOptions) -> String {
+    match print_html_internal(options) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("HTML print failed: {}", e);
+            format!("Print failed: {}", e)
+        }
+    }
+}
+
+fn print_html_internal(options: PrintHtmlOptions) -> Result<String, String> {
+    if options.html.trim().is_empty() {
+        return Err("HTML content cannot be empty".to_string());
+    }
+
+    // Verify wkhtmltopdf is available
+    Command::new("wkhtmltopdf")
+        .arg("--version")
+        .output()
+        .map_err(|_| {
+            "wkhtmltopdf is not installed. Install it with: sudo apt install wkhtmltopdf"
+                .to_string()
+        })?;
+
+    let temp_dir = env::temp_dir();
+    let id = format!(
+        "{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    );
+
+    let html_path = temp_dir.join(format!("tauri_printer_{}.html", id));
+    let pdf_path = temp_dir.join(format!("tauri_printer_{}.pdf", id));
+
+    std::fs::write(&html_path, &options.html)
+        .map_err(|e| format!("Failed to write temp HTML: {}", e))?;
+
+    let mut wk_args: Vec<String> = vec![
+        "--encoding".to_string(),
+        "UTF-8".to_string(),
+        "--enable-local-file-access".to_string(),
+        "--print-media-type".to_string(),
+        "--quiet".to_string(),
+        "--page-size".to_string(),
+        options.page_size.as_deref().unwrap_or("A4").to_string(),
+    ];
+
+    if let Some(ref orientation) = options.orientation {
+        wk_args.extend(["--orientation".to_string(), orientation.clone()]);
+    }
+
+    if let Some(ref margin) = options.margin {
+        let unit = margin.unit.as_deref().unwrap_or("mm");
+        for (flag, val) in [
+            ("--margin-top", margin.top),
+            ("--margin-right", margin.right),
+            ("--margin-bottom", margin.bottom),
+            ("--margin-left", margin.left),
+        ] {
+            if let Some(v) = val {
+                wk_args.extend([flag.to_string(), format!("{}{}", v, unit)]);
+            }
+        }
+    }
+
+    if options.grayscale == Some(true) {
+        wk_args.push("--grayscale".to_string());
+    }
+
+    wk_args.push(html_path.to_string_lossy().to_string());
+    wk_args.push(pdf_path.to_string_lossy().to_string());
+
+    let wk_out = Command::new("wkhtmltopdf")
+        .args(&wk_args)
+        .output()
+        .map_err(|e| format!("Failed to run wkhtmltopdf: {}", e))?;
+
+    let _ = std::fs::remove_file(&html_path);
+
+    if !wk_out.status.success() {
+        return Err(format!(
+            "wkhtmltopdf failed: {}",
+            String::from_utf8_lossy(&wk_out.stderr).trim()
+        ));
+    }
+
+    if !pdf_path.exists() {
+        return Err("PDF generation failed".to_string());
+    }
+
+    Ok(print_pdf(PrintOptions {
+        id: "html_print".to_string(),
+        path: pdf_path.to_string_lossy().to_string(),
+        print_setting: options.printer_id.unwrap_or_default(),
+        remove_after_print: options.remove_after_print.unwrap_or(true),
+    }))
+}
+
+/// List print jobs for a printer using `lpq`.
+pub fn get_jobs(printername: String) -> String {
+    let stdout = Command::new("lpq")
+        .args(["-P", &printername])
+        .output()
+        .map(|o| o.stdout)
+        .unwrap_or_default();
+
+    parse_lpq_output(&String::from_utf8_lossy(&stdout), &printername)
+}
+
+/// Return a specific job by its ID.
+pub fn get_jobs_by_id(printername: String, jobid: String) -> String {
+    let all: Vec<Value> = serde_json::from_str(&get_jobs(printername)).unwrap_or_default();
+    let matched: Vec<&Value> = all
+        .iter()
+        .filter(|j| j["Id"].as_str().unwrap_or("") == jobid)
+        .collect();
+    serde_json::to_string(&matched).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Release (resume) a held job: `lp -i <printer>-<id> -H release`
+pub fn resume_job(printername: String, jobid: String) -> String {
+    run_lp_job_command(&printername, &jobid, "release")
+}
+
+/// Restart a completed/failed job: `lp -i <printer>-<id> -H restart`
+pub fn restart_job(printername: String, jobid: String) -> String {
+    run_lp_job_command(&printername, &jobid, "restart")
+}
+
+/// Hold (pause) a job: `lp -i <printer>-<id> -H hold`
+pub fn pause_job(printername: String, jobid: String) -> String {
+    run_lp_job_command(&printername, &jobid, "hold")
+}
+
+/// Cancel a job: `cancel <printer>-<id>`
+pub fn remove_job(printername: String, jobid: String) -> String {
+    let job_ref = format!("{}-{}", printername, jobid);
+    match Command::new("cancel").args([&job_ref]).output() {
+        Ok(out) if out.status.success() => "Job cancelled".to_string(),
+        Ok(out) => String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        Err(e) => format!("Failed to cancel job: {}", e),
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn run_lp_job_command(printername: &str, jobid: &str, action: &str) -> String {
+    let job_ref = format!("{}-{}", printername, jobid);
+    match Command::new("lp")
+        .args(["-i", &job_ref, "-H", action])
+        .output()
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        Ok(out) => String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        Err(e) => format!("Failed to run lp: {}", e),
+    }
+}
+
+/// Parse `lpq -P <printer>` output into a JSON array.
+///
+/// Example lpq output:
+/// ```text
+/// HP_LaserJet is ready
+/// Rank    Owner   Job     File(s)              Total Size
+/// 1st     alice   42      report.pdf           102400 bytes
+/// ```
+fn parse_lpq_output(output: &str, printername: &str) -> String {
+    let jobs: Vec<Value> = output
+        .lines()
+        .skip(2) // skip status line and header
+        .filter_map(|line| {
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            if cols.len() < 4 {
+                return None;
+            }
+            let (rank, owner, job_id, doc_name) = (cols[0], cols[1], cols[2], cols[3]);
+            let size = cols.get(4).copied().unwrap_or("0");
+            let status = if rank == "active" { "Printing" } else { "Queued" };
+
+            Some(json!({
+                "DocumentName": doc_name,
+                "Id": job_id,
+                "TotalPages": null,
+                "Position": rank,
+                "Size": size,
+                "UserName": owner,
+                "PrinterName": printername,
+                "JobStatus": status,
+                "ComputerName": null,
+                "Priority": 1,
+            }))
+        })
+        .collect();
+
+    serde_json::to_string(&jobs).unwrap_or_else(|_| "[]".to_string())
+}


### PR DESCRIPTION
Fixes #9
The plugin was failing to compile on Linux/macOS because `desktop.rs` referenced` crate::Error::UnsupportedPlatform` which doesn't exist in `error.rs`. Instead of just patching the missing enum variant, this PR implements full Linux and macOS printing support using CUPS

## What's changed

**New file — `src/linux.rs`**
Full CUPS-based implementation for every printer command:
  - `get_printers()` — parses `lpstat -p/-d/-v` output into JSON matching the Windows Get-Printer shape, so frontend code works unchanged across platforms
- `get_printers_by_name()` — filters by name from the same output
- `print_pdf()` — uses `lp -d <printer> <file>` (empty printer name falls back to system default)
- `print_html()` — converts HTML to PDF via `wkhtmltopdf`, then sends to `lp`
- Job management: `get_jobs` / `get_jobs_by_id` via `lpq`, and `resume_job` / `restart_job` / `pause_job` / `remove_job` via `lp -H` and `cancel`

**`src/desktop.rs`**
Routes `print_html` (and other printer methods) to `linux::*` on non-Windows instead of returning `UnsupportedPlatform`.

**`src/lib.rs`**
- Gates `mod windows` with `#[cfg(target_os = "windows")]`
- Adds `#[cfg(not(target_os = "windows"))] mod linux`
- Replaces runtime `if cfg!(windows)` checks with proper compile-time `#[cfg]` blocks

## Requirements on Linux/macOS

- CUPS (standard on most distros and macOS out of the box)
- `wkhtmltopdf` — only needed for `print_html` (`sudo apt install wkhtmltopdf` on Ubuntu/Debian)